### PR TITLE
Add Yarn workspaces

### DIFF
--- a/frontend/form-builder/package.json
+++ b/frontend/form-builder/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "form-builder",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/frontend/form-viewer/package.json
+++ b/frontend/form-viewer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "form-viewer",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "workspaces": [
+    "frontend/form-builder",
+    "frontend/form-viewer"
+  ]
+}


### PR DESCRIPTION
In order to create encapsulation of the two different frontend apps, I've added seperate workspaces for frontend/form-builder and frontend/form-viewer.

This has been tested and confirmed to work using a dummy-package, which has been removed before commiting.