### PR TITLE
Add PostgreSQL in Docker container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,11 @@
 # Building the backend
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 WORKDIR /src
 COPY . .
 RUN dotnet publish "src/FormAPI.csproj" -o /publish
 
 # Serving the backend
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
 WORKDIR /app
 COPY --from=build /publish .
 COPY formfactory.pfx /https/

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 version: '3.8'
 services:
   backend:
+    container_name: formfactory-backend
     build: ./backend
     ports:
       - "8081:8081"
@@ -8,10 +9,29 @@ services:
       - ASPNETCORE_Kestrel__Certificates__Default__Password=123456
       - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/formfactory.pfx
       - ASPNETCORE_URLS=https://+:8081
+    depends_on: 
+      - db
 
   frontend:
+    container_name: formfactory-frontend
     build: .
     ports:
       - "3030:80"
     depends_on:
       - backend
+
+  db:
+    container_name: formfactory-db
+    image: postgres:16.2-alpine
+    restart: always
+    ports:
+      - "5432:5432"
+    volumes:
+      - db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=formfactory
+      - POSTGRES_PASSWORD=123456
+
+volumes:
+  db:
+    driver: local

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,6 +31,7 @@ services:
     environment:
       - POSTGRES_USER=formfactory
       - POSTGRES_PASSWORD=123456
+      - POSTGRES_DB=formfactory
 
 volumes:
   db:


### PR DESCRIPTION
* Created a container named "formfactory-db", which pulls image "postgres:16.2-alpine" from the cloud.
* Made the frontend container depend on the backend container, which again depends on the DB container. This will ensure that all containers are running before it is possible to view the UI in the browser.
* Created a volume for the DB that will persist over multiple sessions.
* Added names "formfactory-backend" and "formfactory-frontend" to existing containers.
* Made the backend Dockerfile fetch the Alpine Linux variant of the images. It is more minimalistic and should use less resources.

Closes #78 