### PR TITLE
Fix/alert text and card width

### DIFF
--- a/frontend/language/src/en.json
+++ b/frontend/language/src/en.json
@@ -27,7 +27,7 @@
   "signup_page.organization.label": "Organization",
   "signup_page.password.label": "Password",
   "signup_page.password.repeat.label": "Repeat password",
-  "signup_page.server.error": "Error connecting to the server",
+  "signup_page.server.error": "The server did not respond as expected. If you are a developer, please make sure the correct backend for your environment is running. If problems persist, please contact us at GitHub.",
   "signup_page.signup.button": "Sign up",
   "signup_page.title": "Sign up",
   "toolbar_tools": "Tools",

--- a/frontend/main-app/src/components/Login/Login.module.css
+++ b/frontend/main-app/src/components/Login/Login.module.css
@@ -5,7 +5,7 @@
   border: 1px solid var(--fds-semantic-border-neutral-subtle);
   border-radius: var(--fds-border_radius-medium);
   padding: var(--fds-spacing-10) var(--fds-spacing-14);
-  width: fit-content;
+  max-width: 400px;
   gap: var(--fds-spacing-8);
 }
 

--- a/frontend/main-app/src/components/Signup/Signup.module.css
+++ b/frontend/main-app/src/components/Signup/Signup.module.css
@@ -5,7 +5,7 @@
   border: 1px solid var(--fds-semantic-border-neutral-subtle);
   border-radius: var(--fds-border_radius-medium);
   padding: var(--fds-spacing-10) var(--fds-spacing-14);
-  width: fit-content;
+  max-width: 400px;
   gap: var(--fds-spacing-8);
 }
 


### PR DESCRIPTION
* Set max-width for Login and Signup cards to 400px, so that it doesn't expand when the error message becomes visible.
* Change the error message to tell the user what is wrong, make the user feel safe, and explain what the user needs to do to move forward.