### PR TITLE
Add hamburger icon to menu

### DIFF
--- a/frontend/main-app/src/components/Header/Header.module.css
+++ b/frontend/main-app/src/components/Header/Header.module.css
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   height: var(--fds-sizing-26);
-  padding: 0 var(--fds-spacing-30);
+  padding: 0 var(--fds-spacing-12);
   border-bottom: 1px solid var(--fds-semantic-border-neutral-subtle);
 }
 

--- a/frontend/main-app/src/components/Header/Header.tsx
+++ b/frontend/main-app/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { Heading, Link } from "@digdir/design-system-react";
-import { ClipboardCheckmarkFillIcon } from "@navikt/aksel-icons";
+import { ClipboardCheckmarkFillIcon, MenuHamburgerIcon } from "@navikt/aksel-icons";
 import classes from "./Header.module.css";
 import { DropdownMenu } from "@digdir/design-system-react";
 import { useTranslation } from "react-i18next";
@@ -32,7 +32,9 @@ export const Header = (): React.JSX.Element => {
       <header className={classes.header}>
         <HeadingBrand />
         <DropdownMenu size="small">
-          <DropdownMenu.Trigger>Menu</DropdownMenu.Trigger>
+          <DropdownMenu.Trigger variant="tertiary" icon="true">
+            <MenuHamburgerIcon className={classes.headerIcon} />
+          </DropdownMenu.Trigger>
           <DropdownMenu.Content>
             <DropdownMenu.Group>
               <DropdownMenu.Item asChild>


### PR DESCRIPTION
* Replace "Menu" with hamburger icon.
![image](https://github.com/ErlingHauan/FormFactory/assets/148075168/d6f37bac-f4c3-4a00-ab2d-ca41f4f5a3fd)


* Noticed that the left/right padding in the header did not fit with the distance of the menu elements when in desktop view. The padding has been reduced from 30 to 12.
![image](https://github.com/ErlingHauan/FormFactory/assets/148075168/2289482a-5376-4de0-9a09-c9aa6c46ba05)



Closes #103 