### PR TITLE
Add backend validation to UserDto

### DIFF
--- a/backend/src/Models/UserDto.cs
+++ b/backend/src/Models/UserDto.cs
@@ -1,3 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace FormAPI.Models;
 
-public record UserDto(int Id, string? Email, string? Password, string? Organization);
+public record UserDto
+{
+    public UserDto(int id, string email, string password, string? organization)
+    {
+        Id = id;
+        Email = email;
+        Password = password;
+        Organization = organization;
+    }
+
+    [Required]
+    public int Id { get; init; }
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; init; }
+
+    [Required]
+    [MinLength(8)]
+    public string Password { get; init; }
+
+    public string? Organization { get; init; }
+}


### PR DESCRIPTION
Added validation attributes to UserDto. This makes sure that emails have to be in the email format, and that passwords have to be at least 8 characters. This matches the validation we have in place in the frontend.

When trying to POST to the login or signup endpoint with invalid attributes, the backend returns 400: Bad Request.