### PR TITLE
Fix settings modal display issue and refactor FormPreview component

### DIFF
--- a/frontend/form-builder/src/components/ComponentSettings/SettingsModal.tsx
+++ b/frontend/form-builder/src/components/ComponentSettings/SettingsModal.tsx
@@ -15,7 +15,6 @@ export const SettingsModal = ({
     <Modal ref={modalRef} className={classes.modalWindow}>
       <Modal.Header className={classes.modalHeader}>Settings</Modal.Header>
       <Modal.Content className={classes.modalContent}>
-        <p>Test</p>
         <SettingsContent />
       </Modal.Content>
     </Modal>

--- a/frontend/form-builder/src/components/FormPreview/FormHeading.tsx
+++ b/frontend/form-builder/src/components/FormPreview/FormHeading.tsx
@@ -1,0 +1,12 @@
+import classes from "./FormPreview.module.css";
+import { Heading, Paragraph } from "@digdir/design-system-react";
+import React from "react";
+
+export const FormHeading = ({ form }) => (
+  <div className={classes.formHeading}>
+    <Heading level={4} size="medium">
+      {form?.title}
+    </Heading>
+    <Paragraph>{form?.description}</Paragraph>
+  </div>
+);

--- a/frontend/form-builder/src/components/FormPreview/FormHeading.tsx
+++ b/frontend/form-builder/src/components/FormPreview/FormHeading.tsx
@@ -2,7 +2,11 @@ import classes from "./FormPreview.module.css";
 import { Heading, Paragraph } from "@digdir/design-system-react";
 import React from "react";
 
-export const FormHeading = ({ form }) => (
+interface FormHeadingProps {
+  form: Form;
+}
+
+export const FormHeading = ({ form }: FormHeadingProps) => (
   <div className={classes.formHeading}>
     <Heading level={4} size="medium">
       {form?.title}

--- a/frontend/form-builder/src/components/FormPreview/FormPreview.tsx
+++ b/frontend/form-builder/src/components/FormPreview/FormPreview.tsx
@@ -1,12 +1,13 @@
-import { Heading, Paragraph } from "@digdir/design-system-react";
+import { Heading } from "@digdir/design-system-react";
 import React, { useContext, useEffect, useRef } from "react";
-import { ComponentIcon } from "@navikt/aksel-icons";
 import classes from "./FormPreview.module.css";
 import { useTranslation } from "react-i18next";
 import { useDrop } from "react-dnd";
 import { DraggableItemsType } from "../../types/dndTypes";
 import { FormComponent } from "../../../../main-app/src/components/FormComponent";
 import { FormBuilderContext } from "../../context";
+import { NoComponentsMessage } from "./NoComponentsMessage";
+import { FormHeading } from "./FormHeading";
 
 interface FormPreviewProps {
   modalRef: React.RefObject<HTMLDialogElement>;
@@ -36,8 +37,7 @@ export const FormPreview = ({ modalRef }: FormPreviewProps): React.JSX.Element =
 
   // TODO: Fix buggy behaviour when clicking in mobile view
   const handleClick = (item: FormComponent, index: number) => {
-    item.order = index;
-    setCurrentComponent(item);
+    setCurrentComponent({ ...item, order: index });
     modalRef.current?.showModal();
   };
 
@@ -52,21 +52,6 @@ export const FormPreview = ({ modalRef }: FormPreviewProps): React.JSX.Element =
       ))}
     </>
   );
-  const RenderFormHeading = () => (
-    <div className={classes.formHeading}>
-      <Heading level={4} size="medium">
-        {form?.title}
-      </Heading>
-      <Paragraph>{form?.description}</Paragraph>
-    </div>
-  );
-
-  const RenderNoComponentsMessage = () => (
-    <div className={classes.noComponents}>
-      <ComponentIcon className={classes.noComponentsIcon} />
-      <Paragraph>{t("form_builder.drag.component.message")}</Paragraph>
-    </div>
-  );
 
   return (
     <>
@@ -78,8 +63,8 @@ export const FormPreview = ({ modalRef }: FormPreviewProps): React.JSX.Element =
         className={classes.dropArea}
         style={{ backgroundColor: isOver && "var(--fds-semantic-surface-warning-subtle)" }}
       >
-        <RenderFormHeading />
-        {form?.components?.length === 0 ? <RenderNoComponentsMessage /> : <RenderComponents />}
+        <FormHeading form={form} />
+        {form?.components?.length === 0 ? <NoComponentsMessage /> : <RenderComponents />}
       </div>
     </>
   );

--- a/frontend/form-builder/src/components/FormPreview/FormPreview.tsx
+++ b/frontend/form-builder/src/components/FormPreview/FormPreview.tsx
@@ -35,10 +35,11 @@ export const FormPreview = ({ modalRef }: FormPreviewProps): React.JSX.Element =
     }),
   }));
 
-  // TODO: Fix buggy behaviour when clicking in mobile view
   const handleClick = (item: FormComponent, index: number) => {
     setCurrentComponent({ ...item, order: index });
-    modalRef.current?.showModal();
+    setTimeout(() => {
+      modalRef.current?.showModal();
+    }, 0);
   };
 
   const RenderComponents = () => (

--- a/frontend/form-builder/src/components/FormPreview/NoComponentsMessage.tsx
+++ b/frontend/form-builder/src/components/FormPreview/NoComponentsMessage.tsx
@@ -1,0 +1,15 @@
+import classes from "./FormPreview.module.css";
+import { ComponentIcon } from "@navikt/aksel-icons";
+import { Paragraph } from "@digdir/design-system-react";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export const NoComponentsMessage = () => {
+  const { t } = useTranslation();
+  return (
+    <div className={classes.noComponents}>
+      <ComponentIcon className={classes.noComponentsIcon} />
+      <Paragraph>{t("form_builder.drag.component.message")}</Paragraph>
+    </div>
+  );
+};


### PR DESCRIPTION
### Description

This pull request addresses an issue where the settings modal was not displaying properly due to the slow execution of `setCurrentComponent`. The changes include:

1. Updated the `handleClick` function in `FormPreview.tsx` to use a `setTimeout` function to asynchronously execute `modalRef.current?.showModal()`. This ensures that the state update is completed before showing the modal.

2. Refactored the `FormPreview` component to improve code organization and readability:
   - Extracted the form heading rendering logic into a separate file.
   - Extracted the "no components" message rendering into a separate file.

3. Updated the `SettingsModal` component in `SettingsModal.tsx` to remove the placeholder `<p>Test</p>` element.
